### PR TITLE
Smaller piecewise inclusion constraint by exploiting linearity detection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,8 @@ SumOfSquares = "0.4"
 julia = "1"
 
 [extras]
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["GLPK", "Test"]

--- a/src/L1_heuristic.jl
+++ b/src/L1_heuristic.jl
@@ -6,7 +6,7 @@ Base.copy(l::L1Heuristic) = l
 L1_heuristic(volume::Volume, v::Union{Nothing, Vector{Float64}}=nothing) = L1Heuristic(volume.variable, v)
 Base.show(io::IO, l::L1Heuristic) = print(io, "L1-heuristic(", l.variable, ")")
 
-set_space(space::Space, ::L1Heuristic, ::JuMP.Model) = return space
+set_space(space::Space, ::L1Heuristic, ::JuMP.Model) = space
 
 function power_integrate(exponent, bound)
     exp = exponent + 1
@@ -205,11 +205,10 @@ function l1_integral(set::Sets.Piecewise{T, <:Union{Sets.Ellipsoid{T}, Sets.Poly
     U = MA.promote_operation(*, Float64, T)
     total = zero(MA.promote_operation(+, U, U))
     for (set, piece) in zip(set.sets, set.pieces)
-        polytope = polyhedron(piece)
         # `piece` is a cone, let's cut it with a halfspace
         # We normalize as the norm of each ray is irrelevant
-        cut = normalize(sum(normalize ∘ Polyhedra.coord, rays(polytope))) # Just a heuristic, open to better ideas
-        intersect!(polytope, HalfSpace(cut, one(eltype(cut))))
+        cut = normalize(sum(normalize ∘ Polyhedra.coord, rays(piece))) # Just a heuristic, open to better ideas
+        polytope = piece ∩ HalfSpace(cut, one(eltype(cut)))
         total = MA.add!(total, integrate_gauge_like(set, polytope, decs, val, cache))
     end
     return total

--- a/src/Sets/Sets.jl
+++ b/src/Sets/Sets.jl
@@ -170,7 +170,9 @@ function Piecewise(sets::Vector{<:AbstractSet}, polytope::Polyhedra.Polyhedron{U
         end
     end
     function piece(i, h)
-        return hrep([HalfSpace(edge[2], zero(U)) for edge in graph[i]])
+        # Need to be a polyhedron as `detecthlinearity` needs a solver in `add_constraint_inclusion_domain`
+        return Polyhedra.polyhedron(hrep([HalfSpace(edge[2], zero(U)) for edge in graph[i]]),
+                                    Polyhedra.DefaultLibrary{U}(Polyhedra.default_solver(polytope)))
     end
     pieces = [piece(i, h) for (i, h) in enumerate(halfspaces(polytope))]
     return Piecewise(sets, polytope, pieces, graph)

--- a/src/Sets/recipe.jl
+++ b/src/Sets/recipe.jl
@@ -41,7 +41,7 @@ function dual_contour(f::Function, nhalfspaces::Int, ::Type{T},
         a = point + ray / λ
         intersect!(h, HalfSpace(cone ? -a : a, cone ? zero(T) : one(T)))
     end
-    return polyhedron(h)
+    return polyhedron(h, Polyhedra.DefaultLibrary{T}(Polyhedra.OppositeMockOptimizer))
 end
 
 function Polyhedra.planar_contour(sphere::HyperSphere; npoints=64)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -121,7 +121,7 @@ function variable_set(model::JuMP.AbstractModel, ell::Ellipsoid, space::Space,
                         @constraint(model, q[i] == q[j], domain = @set x'v == 0)
                         # v corresponds to `-n_ij` in LCSS paper
                         Δ = sets[i].Q * v - sets[j].Q * v
-                        inter = polyhedron(set.pieces[i] ∩ set.pieces[j])
+                        inter = set.pieces[i] ∩ set.pieces[j]
                         h = HalfSpace(Δ, zero(eltype(Δ)))
                         @constraint(model, inter ⊆ h)
                     end

--- a/test/Tests/Tests.jl
+++ b/test/Tests/Tests.jl
@@ -1,5 +1,11 @@
 module Tests
 
+using JuMP
+import GLPK
+const lp_solver = optimizer_with_attributes(GLPK.Optimizer, "presolve" => GLPK.ON)
+import Polyhedra
+const lib = Polyhedra.DefaultLibrary{Float64}(lp_solver)
+
 include("utilities.jl")
 
 include("square.jl")

--- a/test/Tests/invariant.jl
+++ b/test/Tests/invariant.jl
@@ -18,7 +18,7 @@ function invariant_square_test(optimizer, config::MOIT.TestConfig,
                                metric::Function, objective_value, set_test)
     model = _model(optimizer)
 
-    □ = polyhedron(HalfSpace([1, 0], 1.0) ∩ HalfSpace([-1, 0], 1) ∩ HalfSpace([0, 1], 1) ∩ HalfSpace([0, -1], 1))
+    □ = polyhedron(HalfSpace([1, 0], 1.0) ∩ HalfSpace([-1, 0], 1) ∩ HalfSpace([0, 1], 1) ∩ HalfSpace([0, -1], 1), lib)
 
     @variable(model, ◯, variable)
     if inner

--- a/test/Tests/square.jl
+++ b/test/Tests/square.jl
@@ -14,7 +14,7 @@ using JuMP
 const MOIT = MOI.Test
 
 const □ = polyhedron(HalfSpace([1, 0], 1.0) ∩ HalfSpace([-1, 0], 1) ∩ HalfSpace([0, 1], 1) ∩ HalfSpace([0, -1], 1))
-const ◇ = polyhedron(convexhull([1.0, 0], [0, 1], [-1, 0], [0, -1]))
+const ◇ = polyhedron(convexhull([1.0, 0], [0, 1], [-1, 0], [0, -1]), lib)
 
 function square_test(optimizer, config::MOIT.TestConfig,
                      inner::Bool, variable::SetProg.AbstractVariable,

--- a/test/recipes.jl
+++ b/test/recipes.jl
@@ -102,7 +102,7 @@ end
         end
     end
     @testset "Piecewise" begin
-        polytope = polyhedron(HalfSpace([1, 0], 1) ∩ HalfSpace([0, 1], 1) ∩ HalfSpace([-1, 1], 1) ∩ HalfSpace([-1, -1], 1) ∩ HalfSpace([1, -1], 1))
+        polytope = polyhedron(HalfSpace([1, 0], 1) ∩ HalfSpace([0, 1], 1) ∩ HalfSpace([-1, 1], 1) ∩ HalfSpace([-1, -1], 1) ∩ HalfSpace([1, -1], 1), lib)
         Q_1 = [1.0 0.0
                0.0 0.0]
         Q_2 = [0.0 0.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+import GLPK
+const lp_solver = GLPK.Optimizer
+import Polyhedra
+const lib = Polyhedra.DefaultLibrary{Float64}(lp_solver)
+
 include("apply.jl")
 include("variables.jl")
 include("L1_heuristic.jl")


### PR DESCRIPTION
It's possible to do reliably now thanks to https://github.com/JuliaPolyhedra/Polyhedra.jl/pull/206
The number of variables goes from 108 to 28 for the first test and 34 to 234 for the second test!