### PR TITLE
Some fixes for examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | [![][docs-stable-img]][docs-stable-url] | [![Build Status][build-img]][build-url] | [![Gitter][gitter-img]][gitter-url] |
 | [![][docs-latest-img]][docs-latest-url] | [![Codecov branch][codecov-img]][codecov-url] | [<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/Discourse_logo.png/799px-Discourse_logo.png" width="64">][discourse-url] |
 
-JuMP extension for Set Programming : optimization with set variables and inclusion/containment constraints. This package allows the formulation of a mathematical program involving and set variables and inclusion/membership constraints in addition to classical variables and constraints supported by JuMP.
+JuMP extension for Set Programming : optimization with set variables and inclusion/containment constraints. This package allows the formulation of a mathematical program involving set variables and inclusion/membership constraints in addition to classical variables and constraints supported by JuMP.
 
 ## Documentation
 
@@ -121,7 +121,7 @@ To compute the maximal invariant set contained in a polytope (*not yet implement
 ```julia
 using SetProg
 model = Model(optimizer_constructor)
-@variable(model, S, Polyhedron())
+@variable(model, S, Polytope())
 @constraint(model, S ⊆ diamond)
 @constraint(model, A*S ⊆ S) # Invariance constraint
 @objective(model, Max, volume(S))

--- a/src/inclusion.jl
+++ b/src/inclusion.jl
@@ -27,7 +27,7 @@ end
 
 JuMP.function_string(print_mode, c::InclusionConstraint) = string(c.subset)
 function JuMP.in_set_string(print_mode, c::InclusionConstraint)
-    string(print_mode == JuMP.IJuliaMode ? "\\subseteq" : "⊆", " ", c.supset)
+    string(print_mode == MIME("text/latex") ? "\\subseteq" : "⊆", " ", c.supset)
 end
 struct PowerSet{S}
     set::S

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -57,7 +57,7 @@ struct GramTransformation{T, MT <: MP.AbstractMonomial,
 end
 
 function apply_transformation(p::SumOfSquares.GramMatrix,
-                              t::GramTransformation) where T
+                              t::GramTransformation)
     new_n = length(t.monos)
     new_Q = [quad_form(t.M[:, i], p.Q, t.M[:, j]) for j in 1:new_n for i in 1:j]
     return GramMatrix(SymMatrix(new_Q, new_n), t.monos)


### PR DESCRIPTION
The replacement of `JuMP.IJuliaMode` came in https://github.com/jump-dev/JuMP.jl/pull/2874, which was before release [v0.23](https://github.com/jump-dev/JuMP.jl/releases/tag/v0.23.0), which is the [minimal required version](https://github.com/blegat/SetProg.jl/blob/ecfedf7ad7d62fd4d0b529dd0b853ff00e64f4c1/Project.toml#L27). So the change should be fine.

Another comment: This command fails:

https://github.com/blegat/SetProg.jl/blob/ecfedf7ad7d62fd4d0b529dd0b853ff00e64f4c1/README.md?plain=1#L103
```
ERROR: The polyhedron contains euclidean ball of arbitrary large radius.
```

The message does not make sense because the set is bounded. The example works fine with `cheby_center = [0.3, 0.3]`.